### PR TITLE
Prevent duplicate meta descriptions

### DIFF
--- a/src/Resources/contao/classes/Tiles.php
+++ b/src/Resources/contao/classes/Tiles.php
@@ -407,6 +407,8 @@ class Tiles extends Frontend
      */
     protected function prepareData($objData)
     {
+        global $objPage;
+        
         $arrWebappThemeColor = StringUtil::deserialize($objData->webappThemeColor, true);
         $strWebappThemeColor = $arrWebappThemeColor[0];
 
@@ -462,6 +464,10 @@ class Tiles extends Frontend
                 'webappThemeColor' => $strWebappThemeColor,
                 'webappBackgroundColor' => $strWebappBackgroundColor,
             ];
+            
+            if (!empty($objPage->description)) {
+                unset($arrWebapp['webappDescription']);
+            }
         }
 
         if ($objData->addIos) {


### PR DESCRIPTION
Do not include meta description if meta description has already been entered via the page structure on a questionable page.