### PR TITLE
Enforce string value for windowsRssFrequency

### DIFF
--- a/src/Resources/contao/classes/Tiles.php
+++ b/src/Resources/contao/classes/Tiles.php
@@ -471,7 +471,7 @@ class Tiles extends Frontend
                     $arrWindows,
                     [
                         'windowsRss' => $objData->windowsRss,
-                        'windowsRssFrequency' => $strWindowsRssFrequency,
+                        'windowsRssFrequency' => (string) $strWindowsRssFrequency,
                     ]
                 );
             }


### PR DESCRIPTION
Value is used for str_replace() which requires string or array value and otherwise throws an type error